### PR TITLE
Update startup guides

### DIFF
--- a/_posts/2020-08-03-getting-started-on-Xen.markdown
+++ b/_posts/2020-08-03-getting-started-on-Xen.markdown
@@ -80,7 +80,13 @@ sudo make install
 All that's left to do is to run `hvmid` and start a VM to be introspected:
 
 ```shell
-./hvmid
+./hvmid --start
+```
+
+To stop the daemon use:
+
+```shell
+./hvmid --kill
 ```
 
 You can use `journalctl -t hvmid` to check the logs. You should see something like this (note that I will skip some uninteresting log lines):

--- a/_posts/2020-08-03-getting-started-on-kvm.markdown
+++ b/_posts/2020-08-03-getting-started-on-kvm.markdown
@@ -275,8 +275,10 @@ cp default.json <uuid>.json
 
 ```shell
 sudo su -
-LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/hvmid
+LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/hvmid --start
 ```
+
+Use `--kill` to stop the daemon.
 
 ## Power on the target guest VM
 


### PR DESCRIPTION
Made the startup guide work with the new `hvmid` version from hvmi/hvmi#15.