### PR TITLE
KVM guide: pkg-config and uuid-dev are needed to build libbdvmi

### DIFF
--- a/_posts/2020-08-03-getting-started-on-kvm.markdown
+++ b/_posts/2020-08-03-getting-started-on-kvm.markdown
@@ -118,7 +118,7 @@ sudo make install
 ### Install libbdvmi
 
 ```shell
-sudo apt install libboost-all-dev libxen-dev
+sudo apt install libboost-all-dev libxen-dev pkg-config uuid-dev
 git clone https://github.com/bitdefender/libbdvmi.git
 cd libbdvmi
 ./bootstrap


### PR DESCRIPTION
When building everything using `build-dep` exclusively, two extra packages need to be installed manually.